### PR TITLE
ci: deployment and versioning

### DIFF
--- a/.changeset/gold-phones-move.md
+++ b/.changeset/gold-phones-move.md
@@ -1,0 +1,5 @@
+---
+"@privanote/collaborators": patch
+---
+
+Fixing ci workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies
         run: bun install
+      - name: Build packages
+        run: bun run pkg-all build
       - name: Setup NPM Github Package Registry
         run: |
           cat << EOF > "$HOME/.npmrc"
@@ -26,6 +28,6 @@ jobs:
         with:
           commit: "chore: update versions"
           title: "chore: update versions"
-          publish: bun run pkg-all release
+          publish: bunx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seems changesets recursively publish packages, so should be called at the end after packages are built

ref: https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish